### PR TITLE
feat: expose `Node.remove()`

### DIFF
--- a/mod_test.ts
+++ b/mod_test.ts
@@ -792,6 +792,33 @@ Deno.test("Node - isComment identifies comment nodes", () => {
   assertEquals(hasComment, true);
 });
 
+Deno.test("Node - remove whitespace trivia node", () => {
+  const text = '{"a":1 }';
+  const root = parse(text);
+  const obj = root.asObjectOrThrow();
+
+  const children = obj.children();
+  for (const c of children) {
+    if (c.isWhitespace()) {
+      c.remove();
+    }
+  }
+  assertEquals(root.toString(), '{"a":1}');
+});
+
+Deno.test("Node - remove comment trivia node", () => {
+  const text = `{/* remove me */"a": 1/* remove me */}`;
+  const root = parse(text);
+  const obj = root.asObjectOrThrow();
+  const children = obj.children();
+  for (const c of children) {
+    if (c.isComment()) {
+      c.remove();
+    }
+  }
+  assertEquals(root.toString(), `{"a": 1}`);
+});
+
 Deno.test("RootNode - setValue changes root value", () => {
   const text = "null";
   const root = parse(text);

--- a/rs_lib/src/lib.rs
+++ b/rs_lib/src/lib.rs
@@ -443,6 +443,14 @@ pub struct Node {
 
 #[wasm_bindgen]
 impl Node {
+  /// Removes this node from its parent.
+  /// Works for any node kind, including whitespace, comments, tokens, containers, and leaf values.
+  /// After calling this method, the node is detached from the CST and can no longer be used.
+  #[wasm_bindgen(js_name = remove)]
+  pub fn remove(self) {
+    self.inner.remove();
+  }
+
   /// Returns true if this node is a container (object, array, or property).
   /// @returns true if this is a container node
   #[wasm_bindgen(js_name = isContainer)]


### PR DESCRIPTION
I personally just need to delete some whitespace, but exposing this method would be more useful to me than implementing the complete Whitespace struct (which can be a future improvement, I'd say).