### PR TITLE
fix(cst): better escaping of strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "jsonc-parser"
-version = "0.31.0"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45157f76d8fbe134e0c97403d69ac48989a1e0249a058b20f9f5eeff11bb09f0"
+checksum = "8c2e5dea04f54739ca5694ee06e4448ffda065a55b3427d2b131bd5ea697ea2c"
 dependencies = [
  "indexmap",
  "serde",

--- a/rs_lib/Cargo.toml
+++ b/rs_lib/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 crate-type = ["cdylib"]
 
 [dependencies]
-jsonc-parser = { version = "0.31.0", features = ["cst", "serde", "serde_json", "preserve_order", "error_unicode_width"] }
+jsonc-parser = { version = "0.32.3", features = ["cst", "serde", "serde_json", "preserve_order", "error_unicode_width"] }
 wasm-bindgen = "=0.2.106"
 js-sys = "0.3"
 serde = "1.0"


### PR DESCRIPTION
* https://github.com/dprint/jsonc-parser/pull/77