### PR TITLE
fix(cst): do not accidentally insert indent as string lit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "jsonc-parser"
-version = "0.32.3"
+version = "0.32.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2e5dea04f54739ca5694ee06e4448ffda065a55b3427d2b131bd5ea697ea2c"
+checksum = "840785e1a8b4fdb27be18440a35a81af64820dc185c3973ff8b012d4c6282512"
 dependencies = [
  "indexmap",
  "serde",

--- a/rs_lib/Cargo.toml
+++ b/rs_lib/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 crate-type = ["cdylib"]
 
 [dependencies]
-jsonc-parser = { version = "0.32.3", features = ["cst", "serde", "serde_json", "preserve_order", "error_unicode_width"] }
+jsonc-parser = { version = "0.32.4", features = ["cst", "serde", "serde_json", "preserve_order", "error_unicode_width"] }
 wasm-bindgen = "=0.2.106"
 js-sys = "0.3"
 serde = "1.0"


### PR DESCRIPTION
Ref: https://github.com/dprint/jsonc-parser/pull/79